### PR TITLE
fix Checkbox hardcoded white background with main-1

### DIFF
--- a/packages/themes/src/checkbox.ts
+++ b/packages/themes/src/checkbox.ts
@@ -1,7 +1,15 @@
 import { cva } from 'class-variance-authority';
 
 export const checkbox = cva(
-	['border-2', 'focus:ring-2', 'focus:ring-offset-0', 'focus:ring-gray-10', 'outline-0', 'mr-2'],
+	[
+		'bg-main-1',
+		'border-2',
+		'focus:ring-2',
+		'focus:ring-offset-0',
+		'focus:ring-gray-10',
+		'outline-0',
+		'mr-2',
+	],
 	{
 		variants: {
 			color: {


### PR DESCRIPTION
There is a hardcoded white background for Checkbox component 
<img width="713" alt="image" src="https://user-images.githubusercontent.com/2144887/222115867-1e3e6baa-9894-4c58-b37f-a2ebc9ed586e.png">
